### PR TITLE
Switch to use ft-flow ESLint plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,12 @@ const ERROR = "error";
 
 module.exports = {
     parser: "@babel/eslint-parser",
-    plugins: ["ft-flow", "jsx-a11y", "prettier", "react"],
-    extends: ["eslint:recommended", "prettier"],
+    plugins: ["ft-flow", "jsx-a11y", "react"],
+    extends: [
+        "eslint:recommended",
+        "plugin:ft-flow/recommended",
+        "plugin:prettier/recommended",
+    ],
     env: {
         // TODO(csilvers): once we properly use node.js for node
         // files, get rid of this next line.

--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ const WARN = "warn";
 const ERROR = "error";
 
 module.exports = {
-    parser: "babel-eslint",
-    plugins: ["flowtype", "jsx-a11y", "prettier", "react"],
+    parser: "@babel/eslint-parser",
+    plugins: ["ft-flow", "jsx-a11y", "prettier", "react"],
     extends: ["eslint:recommended", "prettier"],
     env: {
         // TODO(csilvers): once we properly use node.js for node
@@ -15,7 +15,7 @@ module.exports = {
         jest: true,
     },
     settings: {
-        flowtype: {
+        "ft-flow": {
             onlyFilesWithFlowAnnotation: true,
         },
         react: {
@@ -57,7 +57,7 @@ module.exports = {
         "no-undef": ERROR,
         "no-unexpected-multiline": ERROR,
         "no-unreachable": ERROR,
-        "no-unused-expressions": OFF, // This is superseded by flowtype/no-unused-expressions.
+        "no-unused-expressions": OFF, // This is superseded by ft-flow/no-unused-expressions.
         "no-unused-vars": [ERROR, {args: "none", varsIgnorePattern: "^_*$"}],
         "no-useless-call": ERROR,
         "no-var": ERROR,
@@ -72,28 +72,28 @@ module.exports = {
         "valid-jsdoc": OFF, // TODO(kevinb): Enable this since we are using jdocs in some places.
 
         /**
-         * flowtype rules
+         * ft-flow rules
          */
-        "flowtype/boolean-style": [ERROR, "boolean"],
-        "flowtype/define-flow-type": WARN, // Suppress no-undef on flow types.
-        "flowtype/no-dupe-keys": ERROR,
-        "flowtype/no-unused-expressions": [
+        "ft-flow/boolean-style": [ERROR, "boolean"],
+        "ft-flow/define-flow-type": WARN, // Suppress no-undef on flow types.
+        "ft-flow/no-dupe-keys": ERROR,
+        "ft-flow/no-unused-expressions": [
             ERROR,
             {allowShortCircuit: true, allowTernary: true},
         ],
-        "flowtype/no-weak-types": OFF, // Allow any, Object, and Function for now.
-        "flowtype/require-parameter-type": OFF, // Flow may still require parameter types in certain situations.
-        "flowtype/require-return-type": OFF,
-        "flowtype/require-valid-file-annotation": [
+        "ft-flow/no-weak-types": OFF, // Allow any, Object, and Function for now.
+        "ft-flow/require-parameter-type": OFF, // Flow may still require parameter types in certain situations.
+        "ft-flow/require-return-type": OFF,
+        "ft-flow/require-valid-file-annotation": [
             ERROR,
             "always",
             {
                 annotationStyle: "line",
             },
         ],
-        "flowtype/sort": OFF,
-        "flowtype/type-id-match": OFF,
-        "flowtype/use-flow-type": WARN, // Suppress no-unused-vars on flow types.
+        "ft-flow/sort": OFF,
+        "ft-flow/type-id-match": OFF,
+        "ft-flow/use-flow-type": WARN, // Suppress no-unused-vars on flow types.
 
         /**
          * jsx-a11y rules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@khanacademy/eslint-config",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "publishConfig": {
         "access": "public"
     },
@@ -10,11 +10,12 @@
     "license": "MIT",
     "dependencies": {},
     "peerDependencies": {
-        "eslint": "^7.27.0",
+        "@babel/eslint-parser": "^7.18.2",
+        "eslint": "^8",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-babel": "^5.3.1",
         "eslint-plugin-eslint-comments": "^3.2.0",
-        "eslint-plugin-flowtype": "^5.7.2",
+        "eslint-plugin-ft-flow": "^2.0.1",
         "eslint-plugin-graphql": "^4.0.0",
         "eslint-plugin-import": "^2.23.4",
         "eslint-plugin-jsx-a11y": "^6.4.1",
@@ -26,7 +27,7 @@
     },
     "devDependencies": {
         "pre-commit": "^1.2.2",
-        "prettier": "^2.3.0",
+        "prettier": "^2.7.1",
         "pretty-quick": "^3.1.0"
     },
     "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -289,10 +289,10 @@ pre-commit@^1.2.2:
     spawn-sync "^1.0.15"
     which "1.2.x"
 
-prettier@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
-  integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==
+prettier@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-quick@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
## Summary:

We've been moving to use `ft-flow` for linting Flow (instead of `flowtype`) because `ft-flow` supports Flow enums.

Issue: "none"

## Test plan:

Update to this version of the config in a project and check that the Flow lint checks work. Especially, try adding a Flow enum and seeing if the linting handles it without error.